### PR TITLE
ヘッダーを固定する

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Header from "@/components/Header";
+import StickyHeader from "@/components/client/StickyHeader";
 import Footer from "@/components/Footer";
 
 const geistSans = Geist({
@@ -34,8 +34,10 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <div className="min-h-screen flex flex-col">
-          <Header />
-          {children}
+          <StickyHeader />
+          <main className="flex-1 pt-0">
+            {children}
+          </main>
           <Footer />
         </div>
       </body>

--- a/frontend/src/components/client/StickyHeader.tsx
+++ b/frontend/src/components/client/StickyHeader.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Header from '../Header'
+
+export default function StickyHeader() {
+  const [isVisible, setIsVisible] = useState(true)
+  const [lastScrollY, setLastScrollY] = useState(0)
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < 768)
+    }
+    
+    checkMobile()
+    window.addEventListener('resize', checkMobile)
+    
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
+
+  useEffect(() => {
+    const controlHeader = () => {
+      const currentScrollY = window.scrollY
+      
+      if (isMobile) {
+        if (currentScrollY > lastScrollY && currentScrollY > 100) {
+          setIsVisible(false)
+        } else {
+          setIsVisible(true)
+        }
+      } else {
+        setIsVisible(true)
+      }
+      
+      setLastScrollY(currentScrollY)
+    }
+
+    window.addEventListener('scroll', controlHeader)
+    return () => window.removeEventListener('scroll', controlHeader)
+  }, [lastScrollY, isMobile])
+
+  return (
+    <div className={`
+      ${isMobile ? 'fixed' : 'sticky'} 
+      top-0 
+      w-full 
+      z-50 
+      transition-transform 
+      duration-300 
+      ${isVisible ? 'translate-y-0' : '-translate-y-full'}
+    `}>
+      <Header />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- デスクトップでは常時ヘッダーを上部に固定表示
- モバイルでは上向きスクロール時にヘッダーを表示、下向きスクロール時に隠す動作を実装

## Changes
- `StickyHeader`コンポーネントを新規作成
- デスクトップ: `sticky`ポジションで常時固定
- モバイル: `fixed`ポジションでスクロール方向に応じて表示/非表示
- レスポンシブ対応（768px未満をモバイル判定）
- スムーズなトランジション効果を追加

## Technical Details
- `useEffect`でスクロールイベントとリサイズイベントを監視
- スクロール方向を検出して表示状態を制御
- `z-50`でヘッダーを最前面に配置
- `transition-transform duration-300`でスムーズなアニメーション

## Test plan
- [ ] デスクトップでヘッダーが常時固定されることを確認
- [ ] モバイルで上向きスクロール時にヘッダーが表示されることを確認
- [ ] モバイルで下向きスクロール時にヘッダーが隠れることを確認
- [ ] 画面サイズ変更時に適切に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)